### PR TITLE
Compat with basic-prelude 0.7.0

### DIFF
--- a/src/Database/PostgreSQL/Schema.hs
+++ b/src/Database/PostgreSQL/Schema.hs
@@ -20,6 +20,7 @@ module Database.PostgreSQL.Schema
   ) where
 
 import BasicPrelude               hiding (FilePath, (</>))
+import qualified Control.Exception as E
 import Data.Text                  (unpack)
 import Database.PostgreSQL.Simple
 import Shelly
@@ -76,12 +77,12 @@ psql migration url =
 
 query' :: (FromRow f, ToRow t) => Text -> t -> Text -> IO [f]
 query' q p url =
-  bracket (connectPostgreSQL (encodeUtf8 url)) close $ \c ->
+  E.bracket (connectPostgreSQL (encodeUtf8 url)) close $ \c ->
     query c (fromString $ unpack q) p
 
 execute_' :: Text -> Text -> IO ()
 execute_' q url =
-  bracket (connectPostgreSQL (encodeUtf8 url)) close $ \c ->
+  E.bracket (connectPostgreSQL (encodeUtf8 url)) close $ \c ->
     void $ execute_ c (fromString $ unpack q)
 
 countSchema :: Text -> Text -> IO [Only Int]


### PR DESCRIPTION
Apologies for the ugly import of `Control.Exception`, I can stylish-haskell it if you prefer, I went for minimal diffs instead.